### PR TITLE
15. 3Sum / Medium / JavaScript

### DIFF
--- a/yeongrok/0015-3sum/0015-3sum.js
+++ b/yeongrok/0015-3sum/0015-3sum.js
@@ -1,0 +1,32 @@
+/**
+ * @param {number[]} nums
+ * @return {number[][]}
+ */
+var threeSum = function(nums) {
+    nums.sort((a, b) => a - b);
+    if (nums[0] > 0 || nums[nums.length - 1] < 0) return [];
+
+    let results = [];
+    for (let i = 0; i < nums.length; i++) {
+        let j = i + 1;
+        let k = nums.length - 1;
+
+        while (j < k) {
+            let sum = nums[i] + nums[j] + nums[k];
+            if (sum === 0) {
+                results.push([nums[i], nums[j], nums[k]]);
+                while (nums[j] === nums[j + 1]) j++;
+                j++;
+                k--;
+            } else if (sum < 0) {
+                j++;
+            } else {
+                k--;
+            }
+        }
+
+        while (nums[i] === nums[i + 1]) i++;
+    }
+
+    return results;
+};

--- a/yeongrok/0015-3sum/README.md
+++ b/yeongrok/0015-3sum/README.md
@@ -1,0 +1,41 @@
+<h2><a href="https://leetcode.com/problems/3sum/">15. 3Sum</a></h2><h3>Medium</h3><hr>Can you solve this real interview question? 3Sum - Given an integer array nums, return all the triplets [nums[i], nums[j], nums[k]] such that i != j, i != k, and j != k, and nums[i] + nums[j] + nums[k] == 0.
+
+Notice that the solution set must not contain duplicate triplets.
+
+ 
+
+Example 1:
+
+
+Input: nums = [-1,0,1,2,-1,-4]
+Output: [[-1,-1,2],[-1,0,1]]
+Explanation: 
+nums[0] + nums[1] + nums[2] = (-1) + 0 + 1 = 0.
+nums[1] + nums[2] + nums[4] = 0 + 1 + (-1) = 0.
+nums[0] + nums[3] + nums[4] = (-1) + 2 + (-1) = 0.
+The distinct triplets are [-1,0,1] and [-1,-1,2].
+Notice that the order of the output and the order of the triplets does not matter.
+
+
+Example 2:
+
+
+Input: nums = [0,1,1]
+Output: []
+Explanation: The only possible triplet does not sum up to 0.
+
+
+Example 3:
+
+
+Input: nums = [0,0,0]
+Output: [[0,0,0]]
+Explanation: The only possible triplet sums up to 0.
+
+
+ 
+
+Constraints:
+
+ * 3 <= nums.length <= 3000
+ * -105 <= nums[i] <= 105


### PR DESCRIPTION
### 설명
1. 배열을 오름차순으로 정렬한다.
   1-1. 모두 양수거나 모두 음수라면 3 sum이 0이 될 수 없으므로 빈 배열을 반환한다.
2. triplet의 첫 번째 값(`nums[i]`)는 배열을 순회하며 고정해두고,
   두 번째 값(`nums[j]`)은 i의 다음 요소로,
   세 번째 값`(nums[k]`)은 배열에서 가장 큰 마지막 요소로 간주하고 합을 계산한다.
   2-1. 합이 0이라면 반환할 배열에 triplet을 저장하고 j는 값을 올리고, k는 값을 줄여서 또 다른 triplet을 찾는다.
   2-2. 합이 0보다 작으면 합을 늘려야 하므로 j만 올린다.
   2-3. 합이 0보다 크면 합을 줄여야 하므로 k만 줄인다.
### Time Complexity: O(n^2)
배열 순회(n) * 회차마다 j나 k에 i 이상의 인덱스 값을 할당하며 전체를 탐색해야 할 수 있어서 => n^2

### Space Complexity: O(n)
triplets 저장하기 위한 배열용 공간