### PR TITLE
19. Remove Nth Node From End of List / Medium / TypeScript

### DIFF
--- a/yeongrok/0019-remove-nth-node-from-end-of-list/0019-remove-nth-node-from-end-of-list.ts
+++ b/yeongrok/0019-remove-nth-node-from-end-of-list/0019-remove-nth-node-from-end-of-list.ts
@@ -1,0 +1,36 @@
+/**
+ * Definition for singly-linked list.
+ * class ListNode {
+ *     val: number
+ *     next: ListNode | null
+ *     constructor(val?: number, next?: ListNode | null) {
+ *         this.val = (val===undefined ? 0 : val)
+ *         this.next = (next===undefined ? null : next)
+ *     }
+ * }
+ */
+
+function removeNthFromEnd(head: ListNode | null, n: number): ListNode | null {
+    if (!head.next) return null;
+
+    let sz = 1;
+    let curr = head;
+    while (curr.next) {
+        sz++;
+        curr = curr.next;
+    }
+
+    if (sz === n) {
+        return head.next;
+    }
+
+    curr = head;
+    let index = 0;
+    while (index !== sz - n - 1) {
+        index++;
+        curr = curr.next;
+    }
+    curr.next = curr.next?.next || null;
+
+    return head;
+}

--- a/yeongrok/0019-remove-nth-node-from-end-of-list/README.md
+++ b/yeongrok/0019-remove-nth-node-from-end-of-list/README.md
@@ -1,0 +1,34 @@
+<h2><a href="https://leetcode.com/problems/remove-nth-node-from-end-of-list/">19. Remove Nth Node From End of List</a></h2><h3>Medium</h3><hr><div><p>Given the <code>head</code> of a linked list, remove the <code>n<sup>th</sup></code> node from the end of the list and return its head.</p>
+
+<p>&nbsp;</p>
+<p><strong class="example">Example 1:</strong></p>
+<img alt="" src="https://assets.leetcode.com/uploads/2020/10/03/remove_ex1.jpg" style="width: 542px; height: 222px;">
+<pre><strong>Input:</strong> head = [1,2,3,4,5], n = 2
+<strong>Output:</strong> [1,2,3,5]
+</pre>
+
+<p><strong class="example">Example 2:</strong></p>
+
+<pre><strong>Input:</strong> head = [1], n = 1
+<strong>Output:</strong> []
+</pre>
+
+<p><strong class="example">Example 3:</strong></p>
+
+<pre><strong>Input:</strong> head = [1,2], n = 1
+<strong>Output:</strong> [1]
+</pre>
+
+<p>&nbsp;</p>
+<p><strong>Constraints:</strong></p>
+
+<ul>
+	<li>The number of nodes in the list is <code>sz</code>.</li>
+	<li><code>1 &lt;= sz &lt;= 30</code></li>
+	<li><code>0 &lt;= Node.val &lt;= 100</code></li>
+	<li><code>1 &lt;= n &lt;= sz</code></li>
+</ul>
+
+<p>&nbsp;</p>
+<p><strong>Follow up:</strong> Could you do this in one pass?</p>
+</div>


### PR DESCRIPTION
### 설명
1. linked list를 순회하며 list의 총 size를 구한다 (`sz`)
    1-1. 노드가 하나 뿐이라면 제거할 노드도 `head` 뿐이므로 `null`을 반환한다.
    1-2. `sz`와 `n`이 같다면 `head`를 제거한다는 뜻이므로 `head.next`를 `head`로 반환한다.
3. 다시 head에서부터 제거할 노드의 앞 노드까지 찾아간다.
    해당 노드는 앞에서부터 `sz - n`번째에 있다.
4. 해당 노드의 `next`가 제거할 노드의 다음 노드를 가리키도록 한다.
    제거할 노드에 대한 참조가 사라졌으므로 list에서 제외되었다.
5. `head`를 반환한다.

### Time Complexity: O(n)
n은 list의 길이. 즉 `sz`
`sz`를 구하면서 전체 list를 순회해야 함 : n
다시 처음부터 sz- n번째 노드를 찾아야 하므로 n보다는 작은 회수만큼의 연산이 더해져야 함
결국 n보다 크거나 같고, 2n보다는 적은 수만큼의 연산을 수행함

### Space Complexity: O(1)
`sz`, `curr`, `index` 변수만을 새로 만들어서 쓰고 있기 때문에
상수의 공간 복잡도를 가짐